### PR TITLE
header-based-nonces

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,8 +50,6 @@ type config struct {
 	Create        bool                    `long:"create" description:"Create the wallet if it does not exist"`
 	CreateTemp    bool                    `long:"createtemp" description:"Create a temporary simulation wallet (pass=password) in the data directory indicated; must call with --datadir"`
 	AppDataDir    *cfgutil.ExplicitString `short:"A" long:"appdata" description:"Application data directory for wallet config, databases and logs"`
-	TestNet3      bool                    `long:"testnet" description:"Use the test Bitcoin network (version 3) (default mainnet)"`
-	SimNet        bool                    `long:"simnet" description:"Use the simulation test network (default mainnet)"`
 	CTRedNet      bool                    `long:"ctrednet" description:"Use the ciphrtxt red test network (default mainnet)"`
 	CTIndigoNet   bool                    `long:"ctindigonet" description:"Use the ciphrtxt indigo network (default mainnet)"`
 	NoInitialLoad bool                    `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
@@ -350,14 +348,6 @@ func loadConfig() (*config, []string, error) {
 	// Choose the active network params based on the selected network.
 	// Multiple networks can't be selected simultaneously.
 	numNets := 0
-	if cfg.TestNet3 {
-		activeNet = &netparams.TestNet3Params
-		numNets++
-	}
-	if cfg.SimNet {
-		activeNet = &netparams.SimNetParams
-		numNets++
-	}
 	if cfg.CTRedNet {
 		activeNet = &netparams.CTRedNetParams
 		numNets++
@@ -408,11 +398,11 @@ func loadConfig() (*config, []string, error) {
 
 	// Exit if you try to use a simulation wallet on anything other than
 	// simnet or testnet3.
-	if !cfg.SimNet && cfg.CreateTemp {
-		fmt.Fprintln(os.Stderr, "Tried to create a temporary simulation "+
-			"wallet for network other than simnet!")
-		os.Exit(0)
-	}
+	//if !cfg.SimNet && cfg.CreateTemp {
+	//	fmt.Fprintln(os.Stderr, "Tried to create a temporary simulation "+
+	//		"wallet for network other than simnet!")
+	//	os.Exit(0)
+	//}
 
 	// Ensure the wallet exists or create it when the create flag is set.
 	netDir := networkDir(cfg.AppDataDir.Value, activeNet.Params)

--- a/internal/legacy/keystore/keystore.go
+++ b/internal/legacy/keystore/keystore.go
@@ -476,12 +476,10 @@ func (net *netParams) ReadFrom(r io.Reader) (int64, error) {
 	}
 
 	switch wire.BitcoinNet(binary.LittleEndian.Uint32(uint32Bytes)) {
-	case wire.MainNet:
-		*net = (netParams)(chaincfg.MainNetParams)
-	case wire.TestNet3:
-		*net = (netParams)(chaincfg.TestNet3Params)
-	case wire.SimNet:
-		*net = (netParams)(chaincfg.SimNetParams)
+	case wire.CTIndigoNet:
+		*net = (netParams)(chaincfg.CTIndigoNetParams)
+	case wire.CTRedNet:
+		*net = (netParams)(chaincfg.CTRedNetParams)
 	default:
 		return n64, errors.New("unknown network")
 	}

--- a/netparams/params.go
+++ b/netparams/params.go
@@ -14,30 +14,6 @@ type Params struct {
 	RPCServerPort string
 }
 
-// MainNetParams contains parameters specific running btcwallet and
-// btcd on the main network (wire.MainNet).
-var MainNetParams = Params{
-	Params:        &chaincfg.MainNetParams,
-	RPCClientPort: "8334",
-	RPCServerPort: "8332",
-}
-
-// TestNet3Params contains parameters specific running btcwallet and
-// btcd on the test network (version 3) (wire.TestNet3).
-var TestNet3Params = Params{
-	Params:        &chaincfg.TestNet3Params,
-	RPCClientPort: "18334",
-	RPCServerPort: "18332",
-}
-
-// SimNetParams contains parameters specific to the simulation test network
-// (wire.SimNet).
-var SimNetParams = Params{
-	Params:        &chaincfg.SimNetParams,
-	RPCClientPort: "18556",
-	RPCServerPort: "18554",
-}
-
 // CTIndigoNetParams contains parameters specific to the ciphrtxt indigo network
 // (wire.SimNet).
 var CTIndigoNetParams = Params{

--- a/params.go
+++ b/params.go
@@ -6,4 +6,4 @@ package main
 
 import "github.com/jadeblaquiere/ctcwallet/netparams"
 
-var activeNet = &netparams.MainNetParams
+var activeNet = &netparams.CTIndigoNetParams

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/jadeblaquiere/ctcd/btcec"
 	"github.com/jadeblaquiere/ctcd/chaincfg"
-	"github.com/jadeblaquiere/ctcd/wire"
+	//"github.com/jadeblaquiere/ctcd/wire"
 	"github.com/jadeblaquiere/ctcutil"
 	"github.com/jadeblaquiere/ctcwallet/internal/legacy/keystore"
 	"github.com/jadeblaquiere/ctcwallet/internal/prompt"
@@ -32,9 +32,9 @@ func networkDir(dataDir string, chainParams *chaincfg.Params) string {
 	// paramaters will likely be switched to being named "testnet3" in the
 	// future.  This is done to future proof that change, and an upgrade
 	// plan to move the testnet3 data directory can be worked out later.
-	if chainParams.Net == wire.TestNet3 {
-		netname = "testnet"
-	}
+	//if chainParams.Net == wire.TestNet3 {
+	//	netname = "testnet"
+	//}
 
 	return filepath.Join(dataDir, netname)
 }


### PR DESCRIPTION
Move to header-based nonces for ciphrtxt network - remove references to bitcoin networks (as the block structure is now different)